### PR TITLE
Cron: Register custom aliases before constructing a cron expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "ipl/stdlib": ">=0.12.0"
   },
   "autoload": {
+    "files": ["src/register_cron_aliases.php"],
     "psr-4": {
       "ipl\\Scheduler\\": "src"
     }

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -31,14 +31,6 @@ class Cron implements Frequency
     public function __construct(string $expression)
     {
         $this->cron = new CronExpression($expression);
-
-        if (! CronExpression::supportsAlias('@minutely')) {
-            CronExpression::registerAlias('@minutely', '* * * * *');
-        }
-
-        if (! CronExpression::supportsAlias('@quarterly')) {
-            CronExpression::registerAlias('@quarterly', '0 0 1 */3 *');
-        }
     }
 
     public function isDue(DateTime $dateTime = null): bool

--- a/src/register_cron_aliases.php
+++ b/src/register_cron_aliases.php
@@ -1,0 +1,11 @@
+<?php
+
+use Cron\CronExpression;
+
+if (! CronExpression::supportsAlias('@minutely')) {
+    CronExpression::registerAlias('@minutely', '* * * * *');
+}
+
+if (! CronExpression::supportsAlias('@quarterly')) {
+    CronExpression::registerAlias('@quarterly', '0 0 1 */3 *');
+}


### PR DESCRIPTION
At the moment, the custom aliases are registered after we have constructed the cron expression instance with the provided expression, which might be quite late when the given expression is e.g. `@minutely`. This PR fixes this by constructing the cron expression after we have registered all custom aliases.