### PR TITLE
Apply patches from github not from relative paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "composer-exit-on-patch-failure": true,
     "patches": {
       "ramsey/uuid": {
-        "Uuid: Support 8.1": "patches/ramsey_uuid_php81.patch"
+        "Uuid: Support 8.1": "https://raw.githubusercontent.com/Icinga/ipl-scheduler/main/patches/ramsey_uuid_php81.patch"
       }
     }
   }


### PR DESCRIPTION
Otherwise `icinga-php-library` won't apply the patches, as it doesn't know from this relative paths of the patches.