### PR TITLE
Introduce class `OneOff` frequency

### DIFF
--- a/src/OneOff.php
+++ b/src/OneOff.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ipl\Scheduler;
+
+use DateTime;
+use ipl\Scheduler\Contract\Frequency;
+
+class OneOff implements Frequency
+{
+    /** @var DateTime Start time of this frequency */
+    protected $dateTime;
+
+    public function __construct(DateTime $dateTime)
+    {
+        $this->dateTime = clone $dateTime;
+    }
+
+    public function isDue(DateTime $dateTime): bool
+    {
+        return ! $this->isExpired($dateTime) && $this->dateTime == $dateTime;
+    }
+
+    public function getNextDue(DateTime $dateTime): DateTime
+    {
+        if ($this->isExpired($dateTime) || $this->dateTime > $dateTime) {
+            return $this->dateTime;
+        }
+
+        return $dateTime;
+    }
+
+    public function isExpired(DateTime $dateTime): bool
+    {
+        return $this->dateTime < $dateTime;
+    }
+}

--- a/tests/OneOffTest.php
+++ b/tests/OneOffTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ipl\Tests\Scheduler;
+
+use DateTime;
+use ipl\Scheduler\OneOff;
+use PHPUnit\Framework\TestCase;
+
+class OneOffTest extends TestCase
+{
+    public function testIsDue()
+    {
+        $now = new DateTime();
+        $oneOff = new OneOff($now);
+
+        $this->assertTrue($oneOff->isDue($now));
+        $this->assertFalse($oneOff->isDue(new DateTime()));
+    }
+
+    public function testGetNextDue()
+    {
+        $now = new DateTime();
+        $oneOff = new OneOff($now);
+
+        $this->assertSame($now, $oneOff->getNextDue($now));
+        $this->assertEquals($now, $oneOff->getNextDue(clone $now));
+    }
+
+    public function testIsExpired()
+    {
+        $now = new DateTime();
+        $oneOff = new OneOff($now);
+
+        $this->assertFalse($oneOff->isExpired($now));
+        $this->assertTrue($oneOff->isExpired(new DateTime()));
+    }
+}


### PR DESCRIPTION
This allows you to schedule a one-time task for a specific date time. The `None` repeat option of the `ScheduleElement` from ipl-web also depends on this PR.