### PR TITLE
Scheduler: Fix one-off task isn't scheduled just once

### DIFF
--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -215,6 +215,10 @@ class Scheduler
                 $this->emit(static::ON_TASK_RUN, [$task, $promise]);
             });
             $this->emit(static::ON_TASK_SCHEDULED, [$task, $now]);
+
+            if ($frequency instanceof OneOff) {
+                return $this;
+            }
         }
 
         $loop = function () use (&$loop, $task, $frequency): void {
@@ -223,7 +227,7 @@ class Scheduler
 
             $now = new DateTime();
             $nextDue = $frequency->getNextDue($now);
-            if ($frequency->isExpired($nextDue)) {
+            if ($frequency instanceof OneOff || $frequency->isExpired($nextDue)) {
                 $removeTask = function () use ($task, $nextDue): void {
                     $this->remove($task);
                     $this->emit(static::ON_TASK_EXPIRED, [$task, $nextDue]);


### PR DESCRIPTION
The `getNextDue()` of the `OneOff` frequency is always returning the same date time, namely the configured start time. Therefore, `isExpired()` would ever return `false` if called over and over again with the same date time.

```php
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Scheduler::schedule() did not run a task with one-off frequency only once
Failed asserting that 484 matches expected 1.
Expected :1
Actual   :484
```