### PR TITLE
Suggest PHP `ext-ev`

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: phpcs
+          extensions: ev
 
       - name: Setup dependencies
         run: composer require -n --no-progress overtrue/phplint
@@ -61,6 +62,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: phpunit:${{ env.PHPUNIT_VERSION }}
+          extensions: ev
 
       - name: Setup dependencies
         run: composer install -n --no-progress

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "simshaun/recurr": "^5",
     "ipl/stdlib": ">=0.12.0"
   },
+  "suggest": {
+    "ext-ev": "Improves performance, efficiency and avoids system limitations. Highly recommended! (See https://www.php.net/manual/en/intro.ev.php for details)"
+  },
   "autoload": {
     "files": ["src/register_cron_aliases.php"],
     "psr-4": {

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -114,14 +114,14 @@ class SchedulerTest extends TestCase
                 }
             );
 
-        // Tick callbacks are guaranteed to be executed in the order they are enqueued,
-        // thus we will not be able to remove the task before it is finished. Therefore,
-        // we need to use timers with 0 intervals.
-        Loop::addTimer(0, function () use ($task): void {
+        // Wait .001ms for the scheduler to run the task at least 2x before removing it und stopping the event loop.
+        Loop::addTimer(.001, function () use ($task): void {
             $this->scheduler->remove($task);
+
+            Loop::stop();
         });
 
-        $this->runAndStopEventLoop();
+        Loop::run();
 
         // When a task is due before the ongoing promise gets resolved, the scheduler will
         // not cancel it. Instead, it will start a new one for the new operations.


### PR DESCRIPTION
Currently, the React PHP uses `StreamSelect` eventloop, which limits you to only have 1024 open FDs in parallel. However, since the scheduler can run several jobs from any module, this limit can be reached very quickly and will result in a crash with a fatal error. I was even able to reach this limit only with **one** very long running job. See here for reference https://daniel.haxx.se/docs/poll-vs-select.html

This event can run until the memory is exhausted:
```php
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 16384 bytes) in /usr/local/src/ipl-sql/src/Connection.php on line 401
PHP Stack trace:
PHP   1. React\EventLoop\Loop::React\EventLoop\{closure:/usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php:47-57}() /usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php:0
PHP   2. React\EventLoop\ExtEvLoop->run() /usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php:55
PHP   3. React\EventLoop\Tick\FutureTickQueue->tick() /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php:192
```