### PR TITLE
Cron/OneOff: Always use default time zone

### DIFF
--- a/src/Cron.php
+++ b/src/Cron.php
@@ -5,6 +5,7 @@ namespace ipl\Scheduler;
 use Cron\CronExpression;
 use DateTime;
 use DateTimeInterface;
+use DateTimeZone;
 use InvalidArgumentException;
 use ipl\Scheduler\Contract\Frequency;
 
@@ -98,6 +99,7 @@ class Cron implements Frequency
     public function startAt(DateTimeInterface $start): self
     {
         $this->start = clone $start;
+        $this->start->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         return $this;
     }
@@ -112,6 +114,7 @@ class Cron implements Frequency
     public function endAt(DateTimeInterface $end): Frequency
     {
         $this->end = clone $end;
+        $this->end->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         return $this;
     }

--- a/src/OneOff.php
+++ b/src/OneOff.php
@@ -4,17 +4,18 @@ namespace ipl\Scheduler;
 
 use DateTime;
 use DateTimeInterface;
-use InvalidArgumentException;
+use DateTimeZone;
 use ipl\Scheduler\Contract\Frequency;
 
 class OneOff implements Frequency
 {
-    /** @var DateTime Start time of this frequency */
+    /** @var DateTimeInterface Start time of this frequency */
     protected $dateTime;
 
-    public function __construct(DateTime $dateTime)
+    public function __construct(DateTimeInterface $dateTime)
     {
         $this->dateTime = clone $dateTime;
+        $this->dateTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
     }
 
     public function isDue(DateTimeInterface $dateTime): bool

--- a/tests/CronTest.php
+++ b/tests/CronTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Scheduler;
 
 use DateTime;
+use DateTimeZone;
 use InvalidArgumentException;
 use ipl\Scheduler\Contract\Frequency;
 use ipl\Scheduler\Cron;
@@ -131,5 +132,38 @@ class CronTest extends TestCase
         $this->assertSame('@minutely', $fromJson->getExpression());
         $this->assertEquals($start, $fromJson->getStart());
         $this->assertEquals($end, $fromJson->getEnd());
+    }
+
+    public function testSerializeAndDeserializeHandleTimezonesCorrectly()
+    {
+        $oldTz = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $start = new DateTime('01-06-2023T12:00:00', new DateTimeZone('America/New_York'));
+            $end = new DateTime('01-06-2024T07:00:00', new DateTimeZone('America/New_York'));
+
+            $cron = Cron::fromJson(
+                json_encode(
+                    (new Cron('@minutely'))
+                        ->startAt($start)
+                        ->endAt($end)
+                )
+            );
+
+            $this->assertEquals(
+                new DateTime('2023-06-01T18:00:00'),
+                $cron->getStart(),
+                'Cron::jsonSerialize() does not restore the start date with a time zone correctly'
+            );
+
+            $this->assertEquals(
+                new DateTime('2024-06-01T13:00:00'),
+                $cron->getEnd(),
+                'Cron::jsonSerialize() does not restore the end date with a time zone correctly'
+            );
+        } finally {
+            date_default_timezone_set($oldTz);
+        }
     }
 }

--- a/tests/OneOffTest.php
+++ b/tests/OneOffTest.php
@@ -3,7 +3,7 @@
 namespace ipl\Tests\Scheduler;
 
 use DateTime;
-use ipl\Scheduler\Contract\Frequency;
+use DateTimeZone;
 use ipl\Scheduler\OneOff;
 use PHPUnit\Framework\TestCase;
 
@@ -44,5 +44,30 @@ class OneOffTest extends TestCase
 
         $this->assertEquals($oneOff, $fromJson);
         $this->assertEquals($now, $fromJson->getStart());
+    }
+
+    public function testSerializeAndDeserializeHandleTimezonesCorrectly()
+    {
+        $oldTz = date_default_timezone_get();
+        date_default_timezone_set('Europe/Berlin');
+
+        try {
+            $dateTime = new DateTime('01-06-2023T12:00:00', new DateTimeZone('America/New_York'));
+            $oneOff = OneOff::fromJson(json_encode(new OneOff($dateTime)));
+
+            $this->assertEquals(
+                new DateTime('2023-06-01T18:00:00'),
+                $oneOff->getStart(),
+                'OneOff::jsonSerialize() does not restore the start date with a time zone correctly'
+            );
+
+            $this->assertEquals(
+                new DateTime('2023-06-01T18:00:00'),
+                $oneOff->getEnd(),
+                'OneOff::jsonSerialize() does not restore the start/end date with a time zone correctly'
+            );
+        } finally {
+            date_default_timezone_set($oldTz);
+        }
     }
 }


### PR DESCRIPTION
Since `Cron` & `OneOff` frequencies work with `DatemTime` by either
calling the methods of the class manually or constructing from a
serialized representation, time zones can differ from the application's
time zone. However, in the frontend we don't display time zone
information, so the time may appear incorrect. This change ensures that
both frequencies always work with the application's time zone as well.

refs https://github.com/Icinga/icingaweb2-module-reporting/pull/188