### PR TITLE
Upgrade to `react/promise` version 3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "psr/log": "^1",
     "ramsey/uuid": "^4.2.3",
     "react/event-loop": "^1.4",
-    "react/promise": "^2.10",
+    "react/promise": "^3.3",
     "simshaun/recurr": "^5",
     "ipl/stdlib": ">=0.12.0"
   },

--- a/src/Common/Promises.php
+++ b/src/Common/Promises.php
@@ -45,7 +45,7 @@ trait Promises
      * **Example Usage:**
      *
      * ```php
-     * $promise->always(function () use ($uuid, $promise) {
+     * $promise->finally(function () use ($uuid, $promise) {
      *     $promises->removePromise($uuid, $promise);
      * })
      * ```

--- a/src/Contract/Task.php
+++ b/src/Contract/Task.php
@@ -3,7 +3,7 @@
 namespace ipl\Scheduler\Contract;
 
 use Ramsey\Uuid\UuidInterface;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 interface Task
 {
@@ -33,7 +33,7 @@ interface Task
      *
      * This commits the actions in a non-blocking fashion to the event loop and yields a deferred promise
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function run(): ExtendedPromiseInterface;
+    public function run(): PromiseInterface;
 }

--- a/tests/Lib/PromiseBoundTask.php
+++ b/tests/Lib/PromiseBoundTask.php
@@ -5,19 +5,19 @@ namespace ipl\Tests\Scheduler\Lib;
 use ipl\Scheduler\Common\TaskProperties;
 use ipl\Scheduler\Contract\Task;
 use Ramsey\Uuid\Uuid;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 class PromiseBoundTask implements Task
 {
     use TaskProperties;
 
-    /** @var ExtendedPromiseInterface */
+    /** @var PromiseInterface */
     protected $promise;
 
     /** @var int  */
     protected $startedPromises = 0;
 
-    public function __construct(ExtendedPromiseInterface $promise)
+    public function __construct(PromiseInterface $promise)
     {
         $this->promise = $promise;
 
@@ -31,7 +31,7 @@ class PromiseBoundTask implements Task
         return $this->startedPromises;
     }
 
-    public function run(): ExtendedPromiseInterface
+    public function run(): PromiseInterface
     {
         $this->startedPromises++;
 

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -14,7 +14,7 @@ use ipl\Tests\Scheduler\Lib\TaskRejectedException;
 use PHPUnit\Framework\TestCase;
 use React\EventLoop\Loop;
 use React\Promise;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use Throwable;
 
 class SchedulerTest extends TestCase
@@ -38,7 +38,7 @@ class SchedulerTest extends TestCase
 
     public function testSchedulingTasksNotYetDue()
     {
-        $task = new PromiseBoundTask(Promise\resolve());
+        $task = new PromiseBoundTask(Promise\resolve(null));
         $nextDue = new DateTime('+1 week');
 
         $scheduledAt = null;
@@ -60,12 +60,12 @@ class SchedulerTest extends TestCase
     public function testDoesNotScheduleNeverDueTasks()
     {
         $neverRun = true;
-        $task = new PromiseBoundTask(Promise\resolve());
+        $task = new PromiseBoundTask(Promise\resolve(null));
         $this->scheduler
             ->schedule($task, new NeverDueFrequency())
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $_, ExtendedPromiseInterface $p) use (&$neverRun): void {
+                function (Task $_, PromiseInterface $p) use (&$neverRun): void {
                     $neverRun = false;
                 }
             );
@@ -82,12 +82,12 @@ class SchedulerTest extends TestCase
     public function testDueTasksRunImmediately()
     {
         $hasRun = false;
-        $task = new PromiseBoundTask(Promise\resolve());
+        $task = new PromiseBoundTask(Promise\resolve(null));
         $this->scheduler
             ->schedule($task, new ImmediateDueFrequency())
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $t, ExtendedPromiseInterface $_) use (&$hasRun): void {
+                function (Task $t, PromiseInterface $_) use (&$hasRun): void {
                     $hasRun = true;
                 }
             );
@@ -174,7 +174,7 @@ class SchedulerTest extends TestCase
             ->schedule($task, new ImmediateDueFrequency())
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $_, ExtendedPromiseInterface $p) use ($deferred): void {
+                function (Task $_, PromiseInterface $p) use ($deferred): void {
                     $deferred->reject(new TaskRejectedException('rejected'));
                 }
             )
@@ -208,7 +208,7 @@ class SchedulerTest extends TestCase
             ->schedule($task, new ImmediateDueFrequency())
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $_, ExtendedPromiseInterface $p) use ($deferred): void {
+                function (Task $_, PromiseInterface $p) use ($deferred): void {
                     $deferred->resolve(10);
                 }
             )
@@ -232,8 +232,8 @@ class SchedulerTest extends TestCase
 
     public function testCountsWithMultipleScheduledTasks()
     {
-        $task1 = new PromiseBoundTask(Promise\resolve());
-        $task2 = new PromiseBoundTask(Promise\resolve());
+        $task1 = new PromiseBoundTask(Promise\resolve(null));
+        $task2 = new PromiseBoundTask(Promise\resolve(null));
         $task3 = new PromiseBoundTask((new Promise\Deferred())->promise());
 
         $this->scheduler
@@ -255,7 +255,7 @@ class SchedulerTest extends TestCase
 
     public function testDoesNotScheduleExpiredTasks()
     {
-        $task = new PromiseBoundTask(Promise\resolve());
+        $task = new PromiseBoundTask(Promise\resolve(null));
         $frequency = new ExpiringFrequency();
         $frequency->setExpired();
 
@@ -284,7 +284,7 @@ class SchedulerTest extends TestCase
             })
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $t, ExtendedPromiseInterface $_) use ($deferred, $frequency): void {
+                function (Task $t, PromiseInterface $_) use ($deferred, $frequency): void {
                     $frequency->setExpired();
 
                     Loop::addTimer(0, function ($timer) use ($deferred): void {
@@ -314,10 +314,10 @@ class SchedulerTest extends TestCase
             ->schedule($task, new OneOff(new DateTime('+1 milliseconds')))
             ->on(
                 CountableScheduler::ON_TASK_RUN,
-                function (Task $t, ExtendedPromiseInterface $_) use (&$countRuns, $deferred): void {
+                function (Task $t, PromiseInterface $_) use (&$countRuns, $deferred): void {
                     $countRuns += 1;
 
-                    $deferred->resolve();
+                    $deferred->resolve(null);
                 }
             );
 


### PR DESCRIPTION
- Upgrade `react/promise` to current latest version `3.3.0`, for PHP 8.5 support.
    - PHP 8.4 support was introduced in [`v3.2.0`](https://github.com/reactphp/promise/releases/tag/v3.2.0).
    - PHP 8.5 support was inteoduced in [`v3.3.0`](https://github.com/reactphp/promise/releases/tag/v3.3.0).
- Method `resolve()` now requires an argument.
- Method `always()` is deprecated, use `finally()` instead.
- Interface `ExtendedPromiseInterface` has been replaced by `PromiseInterface` since [`v3.0.0`](https://reactphp.org/promise/changelog.html#300-2023-07-11).

The following modules use these interfaces because they implement `Task`:
- [icingaweb2-module-pdfexport](https://github.com/Icinga/icingaweb2-module-pdfexport/pull/84)
- [icingaweb2-module-reporting](https://github.com/Icinga/icingaweb2-module-reporting/pull/264)
- [icingaweb2-module-x509](https://github.com/Icinga/icingaweb2-module-x509/pull/260)

Just for reference: There are other modules like director and vspheredb that are subject to the same changes, not because they use the scheduler, but because they use ReactPHP themselves.

refs #56
