### PR TITLE
Catch up missed runs

### DIFF
--- a/src/Common/FrequencyStatus.php
+++ b/src/Common/FrequencyStatus.php
@@ -13,14 +13,14 @@ enum FrequencyStatus
     /** The frequency has a start date which has not been reached yet */
     case PENDING;
 
-    /** The start date has already been reached, and the end date has not been reached yet. */
+    /** The start date has already been reached, and the end date has not been reached yet */
     case READY;
 
     /** The frequency has an end date which has already been reached */
     case EXPIRED;
 
     /**
-     * Get the frequency status of the frequency to determine if it's ready to run.
+     * Get the frequency status of the frequency to determine if it's ready to run
      *
      * @param Frequency $frequency
      * @param DateTimeInterface $dateTime The reference time to check the frequency's start and end dates against
@@ -29,19 +29,16 @@ enum FrequencyStatus
      */
     public static function fromFrequency(Frequency $frequency, DateTimeInterface $dateTime): self
     {
-        // If the end date of the frequency has already been reached, it's expired.
-        // If the end date is null, it can't expire.
+        // If the frequency has no end date, it will never expire.
         if ($frequency->getEnd() !== null && $frequency->getEnd() < $dateTime) {
             return self::EXPIRED;
         }
 
-        // If the start date of the frequency has not been reached yet, it's pending.
-        // If the start date is null, it has no lower bound and is instantly ready.
+        // If the frequency has no start date, it will never be pending.
         if ($frequency->getStart() !== null && $frequency->getStart() > $dateTime) {
             return self::PENDING;
         }
 
-        // If none of the earlier checks have been triggered, the frequency is ready to run.
         return self::READY;
     }
 

--- a/src/Common/FrequencyStatus.php
+++ b/src/Common/FrequencyStatus.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ipl\Scheduler\Common;
+
+use DateTimeInterface;
+use ipl\Scheduler\Contract\Frequency;
+
+/**
+ * Represents the lifecycle status of a frequency based on its start and end date
+ */
+enum FrequencyStatus
+{
+    /** The frequency has a start date which has not been reached yet */
+    case PENDING;
+
+    /** The start date has already been reached, and the end date has not been reached yet. */
+    case READY;
+
+    /** The frequency has an end date which has already been reached */
+    case EXPIRED;
+
+    /**
+     * Get the frequency status of the frequency to determine if it's ready to run.
+     *
+     * @param Frequency $frequency
+     * @param DateTimeInterface $dateTime The reference time to check the frequency's start and end dates against
+     *
+     * @return self
+     */
+    public static function fromFrequency(Frequency $frequency, DateTimeInterface $dateTime): self
+    {
+        // If the end date of the frequency has already been reached, it's expired.
+        // If the end date is null, it can't expire.
+        if ($frequency->getEnd() !== null && $frequency->getEnd() < $dateTime) {
+            return self::EXPIRED;
+        }
+
+        // If the start date of the frequency has not been reached yet, it's pending.
+        // If the start date is null, it has no lower bound and is instantly ready.
+        if ($frequency->getStart() !== null && $frequency->getStart() > $dateTime) {
+            return self::PENDING;
+        }
+
+        // If none of the earlier checks have been triggered, the frequency is ready to run.
+        return self::READY;
+    }
+}

--- a/src/Common/FrequencyStatus.php
+++ b/src/Common/FrequencyStatus.php
@@ -44,4 +44,34 @@ enum FrequencyStatus
         // If none of the earlier checks have been triggered, the frequency is ready to run.
         return self::READY;
     }
+
+    /**
+     * Get whether the frequency is pending
+     *
+     * @return bool
+     */
+    public function isPending(): bool
+    {
+        return $this === self::PENDING;
+    }
+
+    /**
+     * Get whether the frequency is ready
+     *
+     * @return bool
+     */
+    public function isReady(): bool
+    {
+        return $this === self::READY;
+    }
+
+    /**
+     * Get whether the frequency is expired
+     *
+     * @return bool
+     */
+    public function isExpired(): bool
+    {
+        return $this === self::EXPIRED;
+    }
 }

--- a/src/Contract/Frequency.php
+++ b/src/Contract/Frequency.php
@@ -20,7 +20,7 @@ interface Frequency extends JsonSerializable
      * pass the same time to both params.
      *
      * This method should only be called if $dateTime falls within the scheduled frequency window,
-     * i.e., the {@see FrequencyStatus} is {@see FrequencyStatus::READY}.
+     * i.e., {@see FrequencyStatus::isReady()} is true.
      *
      * @param DateTimeInterface $dateTime
      * @param ?DateTimeInterface $lastRun If null is provided, the frequency is definitely due

--- a/src/Contract/Frequency.php
+++ b/src/Contract/Frequency.php
@@ -39,15 +39,6 @@ interface Frequency extends JsonSerializable
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface;
 
     /**
-     * Get whether the specified time is beyond the frequency's expiry time
-     *
-     * @param DateTimeInterface $dateTime
-     *
-     * @return bool
-     */
-    public function isExpired(DateTimeInterface $dateTime): bool;
-
-    /**
      * Get the start time of this frequency
      *
      * @return ?DateTimeInterface

--- a/src/Contract/Frequency.php
+++ b/src/Contract/Frequency.php
@@ -11,7 +11,7 @@ interface Frequency extends JsonSerializable
     public const SERIALIZED_DATETIME_FORMAT = 'Y-m-d\TH:i:s.ue';
 
     /**
-     * Get whether the frequency is due.
+     * Get whether the frequency is due
      *
      * If $lastRun is set, the last run time is used to determine if the frequency is due at the
      * specified $dateTime or was due since the last run. This can be used to catch up missed runs.

--- a/src/Contract/Frequency.php
+++ b/src/Contract/Frequency.php
@@ -11,13 +11,23 @@ interface Frequency extends JsonSerializable
     public const SERIALIZED_DATETIME_FORMAT = 'Y-m-d\TH:i:s.ue';
 
     /**
-     * Get whether the frequency is due at the specified time
+     * Get whether the frequency is due.
+     *
+     * If $lastRun is set, the last run time is used to determine if the frequency is due at the
+     * specified $dateTime or was due since the last run. This can be used to catch up missed runs.
+     *
+     * To only check if the frequency is due at the specified $dateTime, regardless of the last run time,
+     * pass the same time to both params.
+     *
+     * This method should only be called if $dateTime falls within the scheduled frequency window,
+     * i.e., the {@see FrequencyStatus} is {@see FrequencyStatus::READY}.
      *
      * @param DateTimeInterface $dateTime
+     * @param ?DateTimeInterface $lastRun If null is provided, the frequency is definitely due
      *
      * @return bool
      */
-    public function isDue(DateTimeInterface $dateTime): bool;
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool;
 
     /**
      * Get the next due date relative to the given time

--- a/src/Contract/Task.php
+++ b/src/Contract/Task.php
@@ -32,7 +32,8 @@ interface Task
     /**
      * Get the last run of this task
      *
-     * @return DateTimeInterface|false|null Null if there was no last run and false if the last run is not provided
+     * @return DateTimeInterface|false|null If the last run is null and the frequency is ready, it will run instantly.
+     *   If the last run is false the frequency won't check for last runs as described in {@see Frequency::isDue()}.
      */
     public function getLastRun(): DateTimeInterface|false|null;
 

--- a/src/Contract/Task.php
+++ b/src/Contract/Task.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Scheduler\Contract;
 
+use DateTimeInterface;
 use Ramsey\Uuid\UuidInterface;
 use React\Promise\PromiseInterface;
 
@@ -27,6 +28,13 @@ interface Task
      * @return ?string
      */
     public function getDescription(): ?string;
+
+    /**
+     * Get the last run of this task
+     *
+     * @return DateTimeInterface|false|null Null if there was no last run and false if the last run is not provided
+     */
+    public function getLastRun(): DateTimeInterface|false|null;
 
     /**
      * Run this tasks operations

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -60,7 +60,7 @@ class Cron implements Frequency
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime)->isExpired()) {
             return $this->end;
         }
 

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -44,13 +44,17 @@ class Cron implements Frequency
         $this->expression = $expression;
     }
 
-    public function isDue(DateTimeInterface $dateTime): bool
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
-        if ($this->isExpired($dateTime) || $dateTime < $this->start) {
-            return false;
+        if ($lastRun === null) {
+            return true;
         }
 
-        return $this->cron->isDue($dateTime);
+        return
+            // If the next scheduled run after $lastRun is before $dateTime, a run was missed
+            $this->cron->getNextRunDate($lastRun) < $dateTime
+            // Otherwise check if the expression matches right now
+            || $this->cron->isDue($dateTime);
     }
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -7,6 +7,7 @@ use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
+use ipl\Scheduler\Common\FrequencyStatus;
 use ipl\Scheduler\Contract\Frequency;
 
 use function ipl\Stdlib\get_php_type;
@@ -59,7 +60,7 @@ class Cron implements Frequency
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if ($this->isExpired($dateTime)) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
             return $this->end;
         }
 
@@ -68,11 +69,6 @@ class Cron implements Frequency
         }
 
         return $this->cron->getNextRunDate($dateTime);
-    }
-
-    public function isExpired(DateTimeInterface $dateTime): bool
-    {
-        return $this->end !== null && $this->end < $dateTime;
     }
 
     public function getStart(): ?DateTimeInterface

--- a/src/Cron.php
+++ b/src/Cron.php
@@ -51,11 +51,9 @@ class Cron implements Frequency
             return true;
         }
 
-        return
-            // If the next scheduled run after $lastRun is before $dateTime, a run was missed
-            $this->cron->getNextRunDate($lastRun) < $dateTime
-            // Otherwise check if the expression matches right now
-            || $this->cron->isDue($dateTime);
+        $missedRun = $this->cron->getNextRunDate($lastRun) < $dateTime;
+
+        return $missedRun || $this->cron->isDue($dateTime);
     }
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface

--- a/src/OneOff.php
+++ b/src/OneOff.php
@@ -32,11 +32,6 @@ class OneOff implements Frequency
         return $this->dateTime;
     }
 
-    public function isExpired(DateTimeInterface $dateTime): bool
-    {
-        return $this->dateTime < $dateTime;
-    }
-
     public function getStart(): ?DateTimeInterface
     {
         return $this->dateTime;

--- a/src/OneOff.php
+++ b/src/OneOff.php
@@ -23,7 +23,6 @@ class OneOff implements Frequency
 
     public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
-        // If there was no last run, this frequency is due
         return $lastRun === null;
     }
 

--- a/src/OneOff.php
+++ b/src/OneOff.php
@@ -21,9 +21,10 @@ class OneOff implements Frequency
         $this->dateTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
     }
 
-    public function isDue(DateTimeInterface $dateTime): bool
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
-        return ! $this->isExpired($dateTime) && $this->dateTime == $dateTime;
+        // If there was no last run, this frequency is due
+        return $lastRun === null;
     }
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
@@ -43,7 +44,7 @@ class OneOff implements Frequency
 
     public function getEnd(): ?DateTimeInterface
     {
-        return $this->getStart();
+        return null;
     }
 
     public static function fromJson(string $json): static

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -141,18 +141,27 @@ class RRule implements Frequency
         return $self;
     }
 
-    public function isDue(DateTimeInterface $dateTime): bool
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
-        if ($dateTime < $this->rrule->getStartDate() || $this->isExpired($dateTime)) {
+        if ($lastRun === null) {
+            return true;
+        }
+
+        $lastRunNextDue = $this->getNextRecurrences($lastRun, 1, false);
+        if (! $lastRunNextDue->valid()) {
             return false;
         }
 
+        // If the next recurrence based on $lastRun is before $dateTime,
+        // there is definitely a missed run, so the recurrence rule is due.
+        if ($lastRunNextDue->current() < $dateTime) {
+            return true;
+        }
+
+        // If there are no missed runs, check if $dateTime itself is a recurrence point
         $nextDue = $this->getNextRecurrences($dateTime);
-        if (! $nextDue->valid()) {
-            return false;
-        }
 
-        return $nextDue->current() == $dateTime;
+        return $nextDue->valid() && $nextDue->current() == $dateTime;
     }
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -177,7 +177,7 @@ class RRule implements Frequency
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime)->isExpired()) {
             return $this->getEnd();
         }
 

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -278,13 +278,9 @@ class RRule implements Frequency
     /**
      * Get a set of recurrences relative to the given time
      *
-     * The `$include` parameter controls whether `$dateTime` is included in the result set.
-     * If the rrule has an end date, `$include` also determines whether the end date boundary
-     * is included, as both boundaries of the constraint use the same inclusivity setting.
-     *
      * @param DateTimeInterface $dateTime
      * @param int $limit Limit the recurrences to be generated to the given value
-     * @param bool $include Whether to include the passed date and frequency end date in the result set
+     * @param bool $include Whether to include both the given date and an optional configured end date in the result set
      *
      * @return Generator<DateTimeInterface>
      */

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -148,9 +148,19 @@ class RRule implements Frequency
             return true;
         }
 
-        $lastRunNextDue = $this->getNextRecurrences($lastRun, 1, false);
+        $lastRunNextDue = $this->getNextRecurrences($lastRun, 2);
         if (! $lastRunNextDue->valid()) {
             return false;
+        }
+
+        // Skip the result if it equals $lastRun — we want strictly after. The recurrences are
+        // fetched with $include=true to ensure the end date boundary is part of the result set.
+        // As a consequence, $lastRun itself may be included and needs to be skipped.
+        if ($lastRunNextDue->current() == $lastRun) {
+            $lastRunNextDue->next();
+            if (! $lastRunNextDue->valid()) {
+                return false;
+            }
         }
 
         // If the next recurrence based on $lastRun is before $dateTime,
@@ -171,9 +181,15 @@ class RRule implements Frequency
             return $this->getEnd();
         }
 
-        $nextDue = $this->getNextRecurrences($dateTime, 1, false);
-        if (! $nextDue->valid()) {
-            return $dateTime;
+        $nextDue = $this->getNextRecurrences($dateTime, 2);
+        // Skip the result if it equals $dateTime — we want strictly after. The recurrences are
+        // fetched with $include=true to ensure the end date boundary is part of the result set.
+        // As a consequence, $dateTime itself may be included and needs to be skipped.
+        if ($nextDue->current() == $dateTime) {
+            $nextDue->next();
+            if (! $nextDue->valid()) {
+                return $dateTime;
+            }
         }
 
         return $nextDue->current();
@@ -262,9 +278,13 @@ class RRule implements Frequency
     /**
      * Get a set of recurrences relative to the given time
      *
+     * The `$include` parameter controls whether `$dateTime` is included in the result set.
+     * If the rrule has an end date, `$include` also determines whether the end date boundary
+     * is included, as both boundaries of the constraint use the same inclusivity setting.
+     *
      * @param DateTimeInterface $dateTime
      * @param int $limit Limit the recurrences to be generated to the given value
-     * @param bool $include Whether to include the passed time in the result set
+     * @param bool $include Whether to include the passed date and frequency end date in the result set
      *
      * @return Generator<DateTimeInterface>
      */

--- a/src/RRule.php
+++ b/src/RRule.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use Generator;
 use InvalidArgumentException;
+use ipl\Scheduler\Common\FrequencyStatus;
 use ipl\Scheduler\Contract\Frequency;
 use Recurr\Exception\InvalidRRule;
 use Recurr\Rule as RecurrRule;
@@ -166,7 +167,7 @@ class RRule implements Frequency
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if ($this->isExpired($dateTime)) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
             return $this->getEnd();
         }
 
@@ -176,15 +177,6 @@ class RRule implements Frequency
         }
 
         return $nextDue->current();
-    }
-
-    public function isExpired(DateTimeInterface $dateTime): bool
-    {
-        if ($this->rrule->repeatsIndefinitely()) {
-            return false;
-        }
-
-        return $this->getEnd() !== null && $this->getEnd() < $dateTime;
     }
 
     /**

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -207,7 +207,7 @@ class Scheduler
     {
         $now = new DateTime();
         $frequencyState = FrequencyStatus::fromFrequency($frequency, $now);
-        if ($frequencyState === FrequencyStatus::EXPIRED) {
+        if ($frequencyState->isExpired()) {
             return $this;
         }
 
@@ -221,7 +221,7 @@ class Scheduler
          * If the frequency status is ready, $now falls within the scheduled frequency window,
          * and the due check can be performed as described in {@see Frequency::isDue()}.
          */
-        if ($frequencyState === FrequencyStatus::READY && $frequency->isDue($now, $effectiveLastRun)) {
+        if ($frequencyState->isReady() && $frequency->isDue($now, $effectiveLastRun)) {
             Loop::futureTick(function () use ($task): void {
                 $promise = $this->runTask($task);
                 $this->emit(static::ON_TASK_RUN, [$task, $promise]);

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -4,6 +4,7 @@ namespace ipl\Scheduler;
 
 use DateTime;
 use InvalidArgumentException;
+use ipl\Scheduler\Common\FrequencyStatus;
 use ipl\Scheduler\Common\Promises;
 use ipl\Scheduler\Common\Timers;
 use ipl\Scheduler\Contract\Frequency;
@@ -205,20 +206,33 @@ class Scheduler
     public function schedule(Task $task, Frequency $frequency): static
     {
         $now = new DateTime();
-        if ($frequency->isExpired($now)) {
+        $frequencyState = FrequencyStatus::fromFrequency($frequency, $now);
+        if ($frequencyState === FrequencyStatus::EXPIRED) {
             return $this;
         }
 
-        if ($frequency->isDue($now)) {
+        /**
+         * If the task does not provide a last run time, $now is used instead to skip
+         * checking for missed runs as described in {@see Frequency::isDue()}.
+         */
+        $effectiveLastRun = $task->getLastRun() === false ? $now : $task->getLastRun();
+
+        /**
+         * If the frequency status is ready, $now falls within the scheduled frequency window,
+         * and the due check can be performed as described in {@see Frequency::isDue()}.
+         */
+        if ($frequencyState === FrequencyStatus::READY && $frequency->isDue($now, $effectiveLastRun)) {
             Loop::futureTick(function () use ($task): void {
                 $promise = $this->runTask($task);
                 $this->emit(static::ON_TASK_RUN, [$task, $promise]);
             });
             $this->emit(static::ON_TASK_SCHEDULED, [$task, $now]);
+        }
 
-            if ($frequency instanceof OneOff) {
-                return $this;
-            }
+        $nextDue = $frequency->getNextDue($now);
+        // If the next due date is already reached, we don't need to schedule the task
+        if ($nextDue <= $now) {
+            return $this;
         }
 
         $loop = function () use (&$loop, $task, $frequency): void {
@@ -227,7 +241,7 @@ class Scheduler
 
             $now = new DateTime();
             $nextDue = $frequency->getNextDue($now);
-            if ($frequency instanceof OneOff || $frequency->isExpired($nextDue)) {
+            if ($nextDue <= $now) {
                 $removeTask = function () use ($task, $nextDue): void {
                     $this->remove($task);
                     $this->emit(static::ON_TASK_EXPIRED, [$task, $nextDue]);
@@ -250,7 +264,6 @@ class Scheduler
             $this->emit(static::ON_TASK_SCHEDULED, [$task, $nextDue]);
         };
 
-        $nextDue = $frequency->getNextDue($now);
         $this->attachTimer(
             $task->getUuid(),
             Loop::addTimer($nextDue->getTimestamp() - $now->getTimestamp(), $loop)

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -211,16 +211,8 @@ class Scheduler
             return $this;
         }
 
-        /**
-         * If the task does not provide a last run time, $now is used instead to skip
-         * checking for missed runs as described in {@see Frequency::isDue()}.
-         */
         $effectiveLastRun = $task->getLastRun() === false ? $now : $task->getLastRun();
 
-        /**
-         * If the frequency status is ready, $now falls within the scheduled frequency window,
-         * and the due check can be performed as described in {@see Frequency::isDue()}.
-         */
         if ($frequencyState->isReady() && $frequency->isDue($now, $effectiveLastRun)) {
             Loop::futureTick(function () use ($task): void {
                 $promise = $this->runTask($task);
@@ -230,7 +222,7 @@ class Scheduler
         }
 
         $nextDue = $frequency->getNextDue($now);
-        // If the next due date is already reached, we don't need to schedule the task
+        // If the next due date is already reached, we don't need to schedule the task.
         if ($nextDue <= $now) {
             return $this;
         }

--- a/tests/CronTest.php
+++ b/tests/CronTest.php
@@ -5,7 +5,6 @@ namespace ipl\Tests\Scheduler;
 use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
-use ipl\Scheduler\Contract\Frequency;
 use ipl\Scheduler\Cron;
 use PHPUnit\Framework\TestCase;
 
@@ -59,23 +58,40 @@ class CronTest extends TestCase
         $this->assertEquals('FEB', $cron->getPart(Cron::PART_MONTH));
     }
 
-    public function testIsDueWithStartTime()
+    public function testIsDueWithoutLastRunCheck()
     {
-        $cron = new Cron('* * * * *');
+        // Should run at every full hour
+        $cron = (new Cron('0 * * * *'))
+            ->startAt(new DateTime('12:00'));
 
-        $this->assertTrue($cron->isDue(new DateTime()));
+        // Exactly at a recurrence point
+        $now = new DateTime('12:00');
+        $this->assertTrue($cron->isDue($now, $now));
 
-        $cron->startAt(new DateTime('+1 week'));
-
-        $this->assertFalse($cron->isDue(new DateTime()));
+        // Between to recurrence points
+        $now = new DateTime('12:30');
+        $this->assertFalse($cron->isDue($now, $now));
     }
 
-    public function testIsDueWithEndTime()
+    public function testIsDueWithLastRunCheck()
     {
-        $cron = new Cron('* * * * *');
-        $cron->endAt(new DateTime('-1 week'));
+        // Should run at every full hour
+        $cron = (new Cron('0 * * * *'))
+            ->startAt(new DateTime('12:00'));
 
-        $this->assertFalse($cron->isDue(new DateTime()));
+        $now = new DateTime('13:30');
+
+        // Simulate there was no last run yet
+        $lastRun = null;
+        $this->assertTrue($cron->isDue($now, $lastRun));
+
+        // Simulate the last run was at 12:00, means the 13:00 run was missed
+        $lastRun = new DateTime('12:00');
+        $this->assertTrue($cron->isDue($now, $lastRun));
+
+        // Simulate the last run was at 13:00
+        $lastRun = new DateTime('13:00');
+        $this->assertFalse($cron->isDue($now, $lastRun));
     }
 
     public function testGetNextDueWithStartTime()
@@ -98,19 +114,6 @@ class CronTest extends TestCase
         $cron->endAt($now);
 
         $this->assertEquals($now, $cron->getNextDue(new DateTime('+2 hours')));
-    }
-
-    public function testIsExpiredWithoutEndTime()
-    {
-        $this->assertFalse((new Cron('* * * * *'))->isExpired(new DateTime()));
-    }
-
-    public function testIsExpiredWithEndTime()
-    {
-        $cron = new Cron('* * * * *');
-        $cron->endAt(new DateTime('-2 hours'));
-
-        $this->assertTrue($cron->isExpired(new DateTime()));
     }
 
     public function testJsonSerializeAndDeserialize()

--- a/tests/FrequencyStatusTest.php
+++ b/tests/FrequencyStatusTest.php
@@ -16,15 +16,9 @@ class FrequencyStatusTest extends TestCase
         $rrule = RRule::fromFrequency(RRule::HOURLY);
 
         // No start and end date means always ready, regardless of the date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, new DateTime('1970-01-01'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, new DateTime('1970-01-01'))->isReady());
 
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, new DateTime('9999-12-31'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, new DateTime('9999-12-31'))->isReady());
     }
 
     public function testRRuleWithStartOnly(): void
@@ -34,22 +28,13 @@ class FrequencyStatusTest extends TestCase
             ->startAt($start);
 
         // One hour before the start date
-        $this->assertSame(
-            FrequencyStatus::PENDING,
-            FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('-1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('-1 hour'))->isPending());
 
         // Exactly the start date (start date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, $start)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, $start)->isReady());
 
         // One hour after the start date (no end date, so still ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('+1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('+1 hour'))->isReady());
     }
 
     public function testRRuleWithEndOnly(): void
@@ -59,22 +44,13 @@ class FrequencyStatusTest extends TestCase
             ->endAt($end);
 
         // One hour before the end date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('-1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('-1 hour'))->isReady());
 
         // Exactly the end date (end date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, $end)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, $end)->isReady());
 
         // One hour after the end date
-        $this->assertSame(
-            FrequencyStatus::EXPIRED,
-            FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('+1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('+1 hour'))->isExpired());
     }
 
     public function testRRuleWithStartAndEnd(): void
@@ -86,34 +62,19 @@ class FrequencyStatusTest extends TestCase
             ->endAt($end);
 
         // One hour before the start date
-        $this->assertSame(
-            FrequencyStatus::PENDING,
-            FrequencyStatus::fromFrequency($rrule, new DateTime('11:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, new DateTime('11:00'))->isPending());
 
         // Exactly the start date (start date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, $start)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, $start)->isReady());
 
         // Between start and end date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, new DateTime('13:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, new DateTime('13:00'))->isReady());
 
         // Exactly the end date (end date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($rrule, $end)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, $end)->isReady());
 
         // One hour after the end date
-        $this->assertSame(
-            FrequencyStatus::EXPIRED,
-            FrequencyStatus::fromFrequency($rrule, new DateTime('15:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($rrule, new DateTime('15:00'))->isExpired());
     }
 
     public function testCronWithoutStartAndEnd(): void
@@ -121,15 +82,9 @@ class FrequencyStatusTest extends TestCase
         $cron = (new Cron('0 * * * *'));
 
         // No start and end date means always ready, regardless of the date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, new DateTime('1970-01-01'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, new DateTime('1970-01-01'))->isReady());
 
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, new DateTime('9999-12-31'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, new DateTime('9999-12-31'))->isReady());
     }
 
     public function testCronWithStartOnly(): void
@@ -139,22 +94,13 @@ class FrequencyStatusTest extends TestCase
             ->startAt($start);
 
         // One hour before the start date
-        $this->assertSame(
-            FrequencyStatus::PENDING,
-            FrequencyStatus::fromFrequency($cron, (clone $start)->modify('-1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, (clone $start)->modify('-1 hour'))->isPending());
 
         // Exactly the start date (start date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, $start)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, $start)->isReady());
 
         // One hour after the start date (no end date, so still ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, (clone $start)->modify('+1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, (clone $start)->modify('+1 hour'))->isReady());
     }
 
     public function testCronWithEndOnly(): void
@@ -164,22 +110,13 @@ class FrequencyStatusTest extends TestCase
             ->endAt($end);
 
         // One hour before the end date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, (clone $end)->modify('-1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, (clone $end)->modify('-1 hour'))->isReady());
 
         // Exactly the end date (end date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, $end)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, $end)->isReady());
 
         // One hour after the end date
-        $this->assertSame(
-            FrequencyStatus::EXPIRED,
-            FrequencyStatus::fromFrequency($cron, (clone $end)->modify('+1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, (clone $end)->modify('+1 hour'))->isExpired());
     }
 
     public function testCronWithStartAndEnd(): void
@@ -191,34 +128,19 @@ class FrequencyStatusTest extends TestCase
             ->endAt($end);
 
         // One hour before the start date
-        $this->assertSame(
-            FrequencyStatus::PENDING,
-            FrequencyStatus::fromFrequency($cron, new DateTime('11:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, new DateTime('11:00'))->isPending());
 
         // Exactly the start date (start date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, $start)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, $start)->isReady());
 
         // Between start and end date
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, new DateTime('13:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, new DateTime('13:00'))->isReady());
 
         // Exactly the end date (end date is inclusive, so it's ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($cron, $end)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, $end)->isReady());
 
         // One hour after the end date
-        $this->assertSame(
-            FrequencyStatus::EXPIRED,
-            FrequencyStatus::fromFrequency($cron, new DateTime('15:00'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($cron, new DateTime('15:00'))->isExpired());
     }
 
     public function testOneOff(): void
@@ -227,21 +149,12 @@ class FrequencyStatusTest extends TestCase
         $oneOff = new OneOff($start);
 
         // One hour before the scheduled time
-        $this->assertSame(
-            FrequencyStatus::PENDING,
-            FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('-1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('-1 hour'))->isPending());
 
         // Exactly the scheduled time
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($oneOff, $start)
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($oneOff, $start)->isReady());
 
         // One hour after the scheduled time (no end date, so still ready)
-        $this->assertSame(
-            FrequencyStatus::READY,
-            FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('+1 hour'))
-        );
+        $this->assertTrue(FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('+1 hour'))->isReady());
     }
 }

--- a/tests/FrequencyStatusTest.php
+++ b/tests/FrequencyStatusTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace ipl\Tests\Scheduler;
+
+use DateTime;
+use ipl\Scheduler\Common\FrequencyStatus;
+use ipl\Scheduler\Cron;
+use ipl\Scheduler\OneOff;
+use ipl\Scheduler\RRule;
+use PHPUnit\Framework\TestCase;
+
+class FrequencyStatusTest extends TestCase
+{
+    public function testRRuleWithoutStartAndEnd(): void
+    {
+        $rrule = RRule::fromFrequency(RRule::HOURLY);
+
+        // No start and end date means always ready, regardless of the date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, new DateTime('1970-01-01'))
+        );
+
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, new DateTime('9999-12-31'))
+        );
+    }
+
+    public function testRRuleWithStartOnly(): void
+    {
+        $start = new DateTime('12:00');
+        $rrule = RRule::fromFrequency(RRule::HOURLY)
+            ->startAt($start);
+
+        // One hour before the start date
+        $this->assertSame(
+            FrequencyStatus::PENDING,
+            FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('-1 hour'))
+        );
+
+        // Exactly the start date (start date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, $start)
+        );
+
+        // One hour after the start date (no end date, so still ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, (clone $start)->modify('+1 hour'))
+        );
+    }
+
+    public function testRRuleWithEndOnly(): void
+    {
+        $end = new DateTime('14:00');
+        $rrule = RRule::fromFrequency(RRule::HOURLY)
+            ->endAt($end);
+
+        // One hour before the end date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('-1 hour'))
+        );
+
+        // Exactly the end date (end date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, $end)
+        );
+
+        // One hour after the end date
+        $this->assertSame(
+            FrequencyStatus::EXPIRED,
+            FrequencyStatus::fromFrequency($rrule, (clone $end)->modify('+1 hour'))
+        );
+    }
+
+    public function testRRuleWithStartAndEnd(): void
+    {
+        $start = new DateTime('12:00');
+        $end = new DateTime('14:00');
+        $rrule = RRule::fromFrequency(RRule::HOURLY)
+            ->startAt($start)
+            ->endAt($end);
+
+        // One hour before the start date
+        $this->assertSame(
+            FrequencyStatus::PENDING,
+            FrequencyStatus::fromFrequency($rrule, new DateTime('11:00'))
+        );
+
+        // Exactly the start date (start date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, $start)
+        );
+
+        // Between start and end date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, new DateTime('13:00'))
+        );
+
+        // Exactly the end date (end date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($rrule, $end)
+        );
+
+        // One hour after the end date
+        $this->assertSame(
+            FrequencyStatus::EXPIRED,
+            FrequencyStatus::fromFrequency($rrule, new DateTime('15:00'))
+        );
+    }
+
+    public function testCronWithoutStartAndEnd(): void
+    {
+        $cron = (new Cron('0 * * * *'));
+
+        // No start and end date means always ready, regardless of the date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, new DateTime('1970-01-01'))
+        );
+
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, new DateTime('9999-12-31'))
+        );
+    }
+
+    public function testCronWithStartOnly(): void
+    {
+        $start = new DateTime('12:00');
+        $cron = (new Cron('0 * * * *'))
+            ->startAt($start);
+
+        // One hour before the start date
+        $this->assertSame(
+            FrequencyStatus::PENDING,
+            FrequencyStatus::fromFrequency($cron, (clone $start)->modify('-1 hour'))
+        );
+
+        // Exactly the start date (start date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, $start)
+        );
+
+        // One hour after the start date (no end date, so still ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, (clone $start)->modify('+1 hour'))
+        );
+    }
+
+    public function testCronWithEndOnly(): void
+    {
+        $end = new DateTime('14:00');
+        $cron = (new Cron('0 * * * *'))
+            ->endAt($end);
+
+        // One hour before the end date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, (clone $end)->modify('-1 hour'))
+        );
+
+        // Exactly the end date (end date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, $end)
+        );
+
+        // One hour after the end date
+        $this->assertSame(
+            FrequencyStatus::EXPIRED,
+            FrequencyStatus::fromFrequency($cron, (clone $end)->modify('+1 hour'))
+        );
+    }
+
+    public function testCronWithStartAndEnd(): void
+    {
+        $start = new DateTime('12:00');
+        $end = new DateTime('14:00');
+        $cron = (new Cron('0 * * * *'))
+            ->startAt($start)
+            ->endAt($end);
+
+        // One hour before the start date
+        $this->assertSame(
+            FrequencyStatus::PENDING,
+            FrequencyStatus::fromFrequency($cron, new DateTime('11:00'))
+        );
+
+        // Exactly the start date (start date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, $start)
+        );
+
+        // Between start and end date
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, new DateTime('13:00'))
+        );
+
+        // Exactly the end date (end date is inclusive, so it's ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($cron, $end)
+        );
+
+        // One hour after the end date
+        $this->assertSame(
+            FrequencyStatus::EXPIRED,
+            FrequencyStatus::fromFrequency($cron, new DateTime('15:00'))
+        );
+    }
+
+    public function testOneOff(): void
+    {
+        $start = new DateTime('12:00');
+        $oneOff = new OneOff($start);
+
+        // One hour before the scheduled time
+        $this->assertSame(
+            FrequencyStatus::PENDING,
+            FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('-1 hour'))
+        );
+
+        // Exactly the scheduled time
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($oneOff, $start)
+        );
+
+        // One hour after the scheduled time (no end date, so still ready)
+        $this->assertSame(
+            FrequencyStatus::READY,
+            FrequencyStatus::fromFrequency($oneOff, (clone $start)->modify('+1 hour'))
+        );
+    }
+}

--- a/tests/Lib/BaseTestFrequency.php
+++ b/tests/Lib/BaseTestFrequency.php
@@ -13,11 +13,6 @@ abstract class BaseTestFrequency implements Frequency
         return true;
     }
 
-    public function isExpired(DateTimeInterface $dateTime): bool
-    {
-        return false;
-    }
-
     public function getStart(): ?DateTimeInterface
     {
         return null;

--- a/tests/Lib/BaseTestFrequency.php
+++ b/tests/Lib/BaseTestFrequency.php
@@ -8,7 +8,7 @@ use LogicException;
 
 abstract class BaseTestFrequency implements Frequency
 {
-    public function isDue(DateTimeInterface $dateTime): bool
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
         return true;
     }

--- a/tests/Lib/ExpiringFrequency.php
+++ b/tests/Lib/ExpiringFrequency.php
@@ -3,34 +3,27 @@
 namespace ipl\Tests\Scheduler\Lib;
 
 use DateTimeInterface;
+use ipl\Scheduler\Common\FrequencyStatus;
 
 class ExpiringFrequency extends BaseTestFrequency
 {
-    /** @var bool */
-    protected $expired = false;
-
-    /** @var DateTimeInterface */
+    /** @var ?DateTimeInterface */
     protected $end;
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if ($this->isExpired($dateTime)) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
             return $this->end;
         }
 
-        return $dateTime;
+        // Return a future time so the scheduler sets up a timer instead of hitting the
+        // $nextDue <= $now early return, which would prevent the $loop callback from running.
+        return (clone $dateTime)->modify('+1 second');
     }
 
-    public function isExpired(DateTimeInterface $dateTime): bool
+    public function getEnd(): ?DateTimeInterface
     {
-        return $this->expired;
-    }
-
-    public function setExpired(bool $value = true): static
-    {
-        $this->expired = $value;
-
-        return $this;
+        return $this->end;
     }
 
     public function endAt(DateTimeInterface $dateTime): static

--- a/tests/Lib/ExpiringFrequency.php
+++ b/tests/Lib/ExpiringFrequency.php
@@ -12,7 +12,7 @@ class ExpiringFrequency extends BaseTestFrequency
 
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        if (FrequencyStatus::fromFrequency($this, $dateTime) === FrequencyStatus::EXPIRED) {
+        if (FrequencyStatus::fromFrequency($this, $dateTime)->isExpired()) {
             return $this->end;
         }
 

--- a/tests/Lib/ImmediateDueFrequency.php
+++ b/tests/Lib/ImmediateDueFrequency.php
@@ -8,6 +8,9 @@ class ImmediateDueFrequency extends BaseTestFrequency
 {
     public function getNextDue(DateTimeInterface $dateTime): DateTimeInterface
     {
-        return $dateTime;
+        // Return a future time so the scheduler sets up a timer instead of hitting the
+        // $nextDue <= $now early return, which would prevent the $loop callback from running.
+        // One millisecond to be close to immediate.
+        return (clone $dateTime)->modify('+1 millisecond');
     }
 }

--- a/tests/Lib/NeverDueFrequency.php
+++ b/tests/Lib/NeverDueFrequency.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 
 class NeverDueFrequency extends BaseTestFrequency
 {
-    public function isDue(DateTimeInterface $dateTime): bool
+    public function isDue(DateTimeInterface $dateTime, ?DateTimeInterface $lastRun = null): bool
     {
         return false;
     }

--- a/tests/Lib/PromiseBoundTask.php
+++ b/tests/Lib/PromiseBoundTask.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Scheduler\Lib;
 
+use DateTimeInterface;
 use ipl\Scheduler\Common\TaskProperties;
 use ipl\Scheduler\Contract\Task;
 use Ramsey\Uuid\Uuid;
@@ -29,6 +30,11 @@ class PromiseBoundTask implements Task
     public function getStartedPromises(): int
     {
         return $this->startedPromises;
+    }
+
+    public function getLastRun(): DateTimeInterface|false|null
+    {
+        return false;
     }
 
     public function run(): PromiseInterface

--- a/tests/OneOffTest.php
+++ b/tests/OneOffTest.php
@@ -11,11 +11,17 @@ class OneOffTest extends TestCase
 {
     public function testIsDue()
     {
-        $now = new DateTime();
-        $oneOff = new OneOff($now);
+        $start = new DateTime();
+        $oneOff = new OneOff($start);
 
+        $now = $start;
+        // No last run provided (null), so the frequency should definitely be due per the interface contract
         $this->assertTrue($oneOff->isDue($now));
-        $this->assertFalse($oneOff->isDue(new DateTime()));
+
+        // Last run is provided ($start). Because a one-off should only be due once,
+        // it should not be due again if a last run is provided.
+        $now = new DateTime();
+        $this->assertFalse($oneOff->isDue($now, $start));
     }
 
     public function testGetNextDue()
@@ -24,15 +30,6 @@ class OneOffTest extends TestCase
         $oneOff = new OneOff($now);
 
         $this->assertEquals($now, $oneOff->getNextDue(clone $now));
-    }
-
-    public function testIsExpired()
-    {
-        $now = new DateTime();
-        $oneOff = new OneOff($now);
-
-        $this->assertFalse($oneOff->isExpired($now));
-        $this->assertTrue($oneOff->isExpired(new DateTime()));
     }
 
     public function testJsonSerialize()

--- a/tests/OneOffTest.php
+++ b/tests/OneOffTest.php
@@ -57,12 +57,6 @@ class OneOffTest extends TestCase
                 $oneOff->getStart(),
                 'OneOff::jsonSerialize() does not restore the start date with a time zone correctly'
             );
-
-            $this->assertEquals(
-                new DateTime('2023-06-01T18:00:00'),
-                $oneOff->getEnd(),
-                'OneOff::jsonSerialize() does not restore the start/end date with a time zone correctly'
-            );
         } finally {
             date_default_timezone_set($oldTz);
         }

--- a/tests/RRuleTest.php
+++ b/tests/RRuleTest.php
@@ -10,49 +10,40 @@ use PHPUnit\Framework\TestCase;
 
 class RRuleTest extends TestCase
 {
-    public function testIsDueWithoutEndTime()
+    public function testIsDueWithoutLastRunCheck()
     {
-        $start = new DateTime();
-        $rrule = RRule::fromFrequency(RRule::MINUTELY)
+        $start = new DateTime('12:00');
+        $rrule = RRule::fromFrequency(RRule::HOURLY)
             ->startAt($start);
 
-        $start->setTime($start->format('H'), $start->format('i'), $start->format('s'));
+        // Exactly a recurrence point
+        $recurrence = (clone $start)->modify('+1 hour');
+        // Use the same dates to skip the last run check
+        $this->assertTrue($rrule->isDue($recurrence, $recurrence));
 
-        $this->assertTrue($rrule->isDue((clone $start)->modify('+1 minute')));
+        // Between two recurrence points
+        $betweenRecurrences = (clone $start)->modify('+30 minutes');
+        // Use the same dates to skip the last run check
+        $this->assertFalse($rrule->isDue($betweenRecurrences, $betweenRecurrences));
     }
 
-    public function testIsDueWithEndTime()
+    public function testIsDueWithLastRunCheck()
     {
-        $start = new DateTime();
-        $start->setTime($start->format('H'), $start->format('i'), $start->format('s'));
+        $start = new DateTime('12:00');
+        // Should run at 12:00, 13:00, 14:00, ...
+        $rrule = RRule::fromFrequency(RRule::HOURLY)
+            ->startAt($start);
 
-        $end = clone $start;
-        $end->modify('+2 minute');
+        $now = (clone $start)->modify('+90 minutes');
 
-        $rrule = RRule::fromFrequency(RRule::MINUTELY)
-            ->startAt($start)
-            ->endAt($end);
+        // Simulate there was no last run yet
+        $this->assertTrue($rrule->isDue($now, null));
 
-        $this->assertTrue($rrule->isDue((clone $start)->modify('+1 minute')));
-        $this->assertFalse($rrule->isDue((clone $end)->modify('+1 minute')));
-    }
+        // Simulate the last run was at 12:00, means the 13:00 was missed
+        $this->assertTrue($rrule->isDue($now, $start));
 
-    public function testIsExpiredWithoutEndTime()
-    {
-        $rrule = RRule::fromFrequency(RRule::MINUTELY)
-            ->startAt(new DateTime());
-
-        $this->assertFalse($rrule->isExpired(new DateTime('+1 day')));
-    }
-
-    public function testIsExpiredWithEndTime()
-    {
-        $rrule = RRule::fromFrequency(RRule::MINUTELY)
-            ->startAt(new DateTime())
-            ->endAt(new DateTime('+5 minute'));
-
-        $this->assertFalse($rrule->isExpired(new DateTime('+2 minute')));
-        $this->assertTrue($rrule->isExpired(new DateTime('+10 minute')));
+        // Simulate the last run was at 13:00
+        $this->assertFalse($rrule->isDue($now, (clone $start)->modify('+1 hour')));
     }
 
     public function testGetNextDueWithoutEndTime()

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -115,7 +115,7 @@ class SchedulerTest extends TestCase
             );
 
         // Wait 0.01s for the scheduler to run the task a couple of times before
-        // removing it und stopping the event loop.
+        // removing it and stopping the event loop.
         Loop::addTimer(.01, function () use ($task): void {
             $this->scheduler->remove($task);
 
@@ -256,8 +256,8 @@ class SchedulerTest extends TestCase
     public function testDoesNotScheduleExpiredTasks()
     {
         $task = new PromiseBoundTask(Promise\resolve(null));
-        $frequency = new ExpiringFrequency();
-        $frequency->setExpired();
+        $frequency = (new ExpiringFrequency())
+            ->endAt(new DateTime('-1 second'));
 
         $this->scheduler->schedule($task, $frequency);
 
@@ -271,34 +271,41 @@ class SchedulerTest extends TestCase
     public function testTaskIsDetachedAfterExpiring()
     {
         $deferred = new Promise\Deferred();
-        $frequency = new ExpiringFrequency();
         $task = new PromiseBoundTask($deferred->promise());
 
-        $expireTime = new DateTime();
-        $frequency->endAt($expireTime);
+        // End time in the future so FrequencyStatus is READY, not immediately EXPIRED.
+        // getNextDue() returns $now + 1 second, so the scheduler creates a 1-second $loop timer.
+        $frequency = (new ExpiringFrequency())
+            ->endAt(new DateTime('+1 minute'));
 
         $expiredAt = null;
         $this->scheduler
             ->on(CountableScheduler::ON_TASK_EXPIRED, function (Task $_, DateTime $expires) use (&$expiredAt): void {
                 $expiredAt = $expires;
+
+                // Stop the loop immediately so the test doesn't wait for the safety timer
+                Loop::stop();
             })
             ->on(
                 CountableScheduler::ON_TASK_RUN,
                 function (Task $t, PromiseInterface $_) use ($deferred, $frequency): void {
-                    $frequency->setExpired();
+                    // Move end to the past so the next $loop call detects expiry
+                    $frequency->endAt(new DateTime('-1 second'));
 
-                    Loop::addTimer(0, function ($timer) use ($deferred): void {
-                        $deferred->resolve(0);
-
-                        Loop::cancelTimer($timer);
-                    });
+                    // Resolve so the expiry path's Promise\all() can complete
+                    $deferred->resolve(null);
                 }
             )
             ->schedule($task, $frequency);
 
-        $this->runAndStopEventLoop();
+        // Safety timer to keep the loop alive long enough for the 1-second $loop timer to fire.
+        // If the expiration is detected earlier, the loop stops instantly.
+        Loop::addTimer(5, function (): void {
+            Loop::stop();
+        });
+        Loop::run();
 
-        $this->assertEquals($expireTime, $expiredAt, 'Scheduler::schedule() did not get expected expire time');
+        $this->assertNotNull($expiredAt, 'Scheduler::schedule() did not get expected expire time');
 
         $this->assertEquals(0, $this->scheduler->count(), 'Scheduler::schedule() did not remove expired task');
         $this->assertEquals(0, $this->scheduler->countTimers());
@@ -311,7 +318,7 @@ class SchedulerTest extends TestCase
         $deferred = new Promise\Deferred();
         $task = new PromiseBoundTask($deferred->promise());
         $this->scheduler
-            ->schedule($task, new OneOff(new DateTime('+1 milliseconds')))
+            ->schedule($task, new OneOff(new DateTime('+1 second')))
             ->on(
                 CountableScheduler::ON_TASK_RUN,
                 function (Task $t, PromiseInterface $_) use (&$countRuns, $deferred): void {
@@ -321,7 +328,11 @@ class SchedulerTest extends TestCase
                 }
             );
 
-        $this->runAndStopEventLoop();
+        // Wait long enough for the 1-second timer to fire and detect that OneOff has no next occurrence
+        Loop::addTimer(2, function (): void {
+            Loop::stop();
+        });
+        Loop::run();
 
         $this->assertEquals(0, $this->scheduler->count());
         $this->assertEquals(0, $this->scheduler->countTimers());


### PR DESCRIPTION
### Current Implementation

Currently, each Frequency implementation (`Cron`, `RRule`, `OneOff`) handles its own start/end date window checks via an `isExpired()` method, and `isDue()` combined both the window check and the recurrence match into a single call. The `Scheduler` duplicates some of this logic and uses `instanceof OneOff` checks to handle one-off task completion. There is no way to detect missed runs. If the scheduler isn't running when a task is due, that occurrence will be skipped silently.

### Changes

This refactoring separates the frequency lifecycle from the due check. A new `FrequencyStatus` enum centralizes the start/end date window logic into `fromFrequency()`, returning `PENDING`, `READY`, or `EXPIRED`. The `isExpired()` method is removed from the `Frequency` interface entirely.

`isDue()` now accepts an optional `$lastRun` parameter for missed run detection. If `null`, the frequency is definitely due. If set, implementations check whether a run was missed since that time. To support this, `Task` gains a `getLastRun()` method.

The `Scheduler` uses `FrequencyStatus` to decide whether to call `isDue()` at all, and replaces the `instanceof OneOff` / `isExpired()` checks with a single `$nextDue <= $now` condition that handles both one-off completion and expiration generically.

`RRule::isDue()` and `getNextDue()` are fixed to use inclusive recurrence boundaries, ensuring the end date is part of the result set. `OneOff::getEnd()` now returns `null` since a one-off has no end date.