### PR TITLE
Repository housekeeping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude Git and CI configuration files from archives.
+.git* export-ignore
+
+# Exclude test-related files from archives.
+tests/ export-ignore
+phpstan* export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+      - support/*
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   php:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-# Exclude all hidden files
-.*
-
-# Except those related to Git (and GitHub)
-!.git*
-
-# Exclude files from composer install
-vendor/
+# Ignore Composer installation artifacts; composer.lock is intentionally
+# excluded as this is a library - applications depending on this package
+# manage their own lock file.
+/vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,25 @@
 {
   "name": "ipl/scheduler",
-  "type": "library",
   "description": "Icinga PHP Library - Tasks scheduler",
-  "keywords": ["task", "job", "scheduler", "cron"],
-  "homepage": "https://github.com/Icinga/ipl-scheduler",
   "license": "MIT",
-  "config": {
-    "sort-packages": true
-  },
+  "type": "library",
+  "keywords": [
+    "task",
+    "job",
+    "scheduler",
+    "cron"
+  ],
+  "homepage": "https://github.com/Icinga/ipl-scheduler",
   "require": {
     "php": ">=8.2",
     "ext-json": "*",
     "dragonmantank/cron-expression": "^3",
+    "ipl/stdlib": ">=0.12.0",
     "psr/log": "^1",
     "ramsey/uuid": "^4.2.3",
     "react/event-loop": "^1.4",
     "react/promise": "^3.3",
-    "simshaun/recurr": "^5",
-    "ipl/stdlib": ">=0.12.0"
+    "simshaun/recurr": "^5"
   },
   "require-dev": {
     "ipl/stdlib": "dev-main"
@@ -26,14 +28,19 @@
     "ext-ev": "Improves performance, efficiency and avoids system limitations. Highly recommended! (See https://www.php.net/manual/en/intro.ev.php for details)"
   },
   "autoload": {
-    "files": ["src/register_cron_aliases.php"],
     "psr-4": {
       "ipl\\Scheduler\\": "src"
-    }
+    },
+    "files": [
+      "src/register_cron_aliases.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {
       "ipl\\Tests\\Scheduler\\": "tests"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
Apply a set of maintenance changes to normalize repository configuration:

- Extend CI to build on `support/*` branches, run for all PRs
  regardless of target, and allow manual dispatch
- Normalize `composer.json`
- Add `.gitattributes` to exclude CI and test files from `git archive`
- Tighten `.gitignore` to cover only Composer artifacts